### PR TITLE
Remove fstring in cell to match Python 3.5

### DIFF
--- a/notebooks/Workshop_LinearRegression_Part1.ipynb
+++ b/notebooks/Workshop_LinearRegression_Part1.ipynb
@@ -351,8 +351,8 @@
     "        train_error.append(mean_squared_error(y_train,y_train_pred))\n",
     "        test_error.append(mean_squared_error(y_test,y_test_pred))\n",
     "\n",
-    "        print(f'MSE on train set: {mean_squared_error(y_train,y_train_pred)}')\n",
-    "        print(f'MSE on validation set: {mean_squared_error(y_test,y_test_pred)}')\n",
+    "        print('MSE on train set:', mean_squared_error(y_train,y_train_pred))\n",
+    "        print('MSE on validation set:', mean_squared_error(y_test,y_test_pred))\n",
     "        \n",
     "    return train_error, test_error"
    ]


### PR DESCRIPTION
Intersect VM's currently on older Python version without f strings

You would obviously have to update other parts of your local notes to remove similar issues.